### PR TITLE
Bugfix function pointer parameters

### DIFF
--- a/Humphrey.Compiler/src/Backend/CompilationUnit.cs
+++ b/Humphrey.Compiler/src/Backend/CompilationUnit.cs
@@ -535,6 +535,7 @@ namespace Humphrey.Backend
             var oldScope = currentScope;
             currentScope = newScope;
             currentScope.PatchScope(root);
+            currentScope.FixParent(oldScope);
             return oldScope;
         }
 
@@ -602,6 +603,10 @@ namespace Humphrey.Backend
 
         public CompilationParam CreateFunctionParameter(CompilationType type, AstIdentifier identifier)
         {
+            if (type is CompilationFunctionType)
+            {
+                type = CreatePointerType(type, type.Location);
+            }
             return new CompilationParam(type, identifier);
         }
 

--- a/Humphrey.Compiler/src/CommonSymbolTable.cs
+++ b/Humphrey.Compiler/src/CommonSymbolTable.cs
@@ -158,5 +158,19 @@ namespace Humphrey
             // If we reach here, glue the symbol tables together
             scope._parent = root;
         }
+
+        internal void FixParent(CommonSymbolTable parent)
+        {
+            if (_parent==null)
+                return;
+            foreach (var v in _parent._valueTable)
+            {
+                var value =  parent.FetchValue(v.Key);
+                if (value!=null && value.Value!=null && v.Value.Value==null)
+                {
+                    _parent._valueTable[v.Key]=value;
+                }
+            }
+        }
     }
 }

--- a/Humphrey.Compiler/src/FrontEnd/AST/AstFunctionCall.cs
+++ b/Humphrey.Compiler/src/FrontEnd/AST/AstFunctionCall.cs
@@ -166,6 +166,12 @@ namespace Humphrey.FrontEnd
             functionType = resolved as AstFunctionType;
             if (functionType == null)
             {
+                var chkPtrToFunction=resolved as AstPointerType;
+                if (chkPtrToFunction!=null)
+                {
+                    resolved=chkPtrToFunction.ElementType;
+                }
+            
                 var baseT = resolved.ResolveBaseType(pass);
                 functionType = baseT as AstFunctionType;
                 if (functionType == null)

--- a/Humphrey.Compiler/src/FrontEnd/AST/AstFunctionCall.cs
+++ b/Humphrey.Compiler/src/FrontEnd/AST/AstFunctionCall.cs
@@ -115,6 +115,11 @@ namespace Humphrey.FrontEnd
                 // we might want to always set this for alloca...
                 allocSpace.Storage = new CompilationValue(allocSpace.BackendValue, unit.CreatePointerType(structType, new SourceLocation(argumentList.Token)), argumentList.Token);
             }
+            if (inputs.Length != ftype.InputCount)
+            {
+                return structType == null ? null : unit.CreateUndef(structType);
+            }
+
             var arguments = new CompilationValue[ftype.Parameters.Length];
             for (uint a = 0; a < inputs.Length;a++)
             {
@@ -143,7 +148,10 @@ namespace Humphrey.FrontEnd
         {
             // pass the input expression results to the input arguments  
             if (argumentList.Expressions.Length != ftype.InputCount)
-                throw new System.Exception($"TODO - this is an error, function call doesn't match function arguments");
+            {
+                unit.Messages.Log(CompilerErrorKind.Error_SignatureMismatch, $"Attempt to call function with wrong number of parameters", Token.Location, Token.Remainder);
+                return new CompilationValue[0];
+            }
             var arguments = new CompilationValue[ftype.InputCount];
             for (uint a = 0; a < argumentList.Expressions.Length; a++)
             {

--- a/Humphrey.Compiler/src/FrontEnd/CompilerMessages.cs
+++ b/Humphrey.Compiler/src/FrontEnd/CompilerMessages.cs
@@ -33,6 +33,7 @@ namespace Humphrey.FrontEnd
         Error_TypeMismatch = Error | CompileError | 0x05,
         Error_SignedUnsignedMismatch = Error | CompileError | 0x06,
         Error_AliasWidthMismatch = Error | CompileError | 0x07, 
+        Error_SignatureMismatch = Error | CompileError | 0x08,
         Error_CompilationAborted = Error | CompileError | 0xFF,
         
         // LLVM block

--- a/Humphrey.Tests/src/JitTests.cs
+++ b/Humphrey.Tests/src/JitTests.cs
@@ -631,6 +631,14 @@ SizeOf : (a:_)(size:[64]bit)=
         }
         
         [Theory]
+        [InlineData(@" FunctionType:()(out:[8]bit) Returns12:FunctionType= { out=12; } DoFunction:(fPtr:FunctionType)(out:[8]bit)={out=fPtr();} Main:(a:[8]bit,b:[8]bit)(out:[8]bit)= { out = a+b+DoFunction(Returns12); } ", "Main", 2,3,17)]
+        [InlineData(@" FunctionType:()(out:[8]bit) Returns12:FunctionType= { out=12; } Returns13:FunctionType= { out=13; } DoFunction:(fPtr:FunctionType)(out:[8]bit)={out=fPtr();} Main:(a:[8]bit,b:[8]bit)(out:[8]bit)= { out = a+b+DoFunction(Returns12)+DoFunction(Returns13); } ", "Main", 2,3,30)]
+        public void CheckFunctionPointerParam(string input, string entryPointName, byte ival1, byte ival2, byte expected)
+        {
+            Assert.True(Input8Bit8BitExpects8BitValue(CompileForTest(input, entryPointName), ival1, ival2, expected), $"Test {entryPointName},{input},{ival1},{ival2},{expected}");
+        }
+        
+        [Theory]
         [InlineData(@" Flags:[64]bit { a:=1<<0 b:=1<<1 c:=1<<2 d:=1<<3} Return:(dc:*[8]bit,in:[8]bit)(out:[8]bit)={ out=in; }  Main:()(out:[8]bit)= { dd:[8]bit=_; out=Return(&dd,(~(Flags.b|Flags.c)) as [8]bit); } ", "Main", 0xF9)]
         public void CheckEnumFlagExpression(string input, string entryPointName, byte expected)
         {

--- a/Humphrey.Tests/src/MessageTests.cs
+++ b/Humphrey.Tests/src/MessageTests.cs
@@ -73,6 +73,7 @@ namespace Humphrey.Tests
         [InlineData("[]", CompilerErrorKind.Error_EmptyMetaDataNode)]
         [InlineData("[%]", CompilerErrorKind.Error_ExpectedIdentifierList)]
         [InlineData("[metadata%]", CompilerErrorKind.Error_ExpectedToken)]
+        [InlineData("func:(bob:bit,carol:bit)()={} main:()()={func(5);}", CompilerErrorKind.Error_SignatureMismatch)]
         public void CheckCompilationMessages(string input, CompilerErrorKind kind)
         {
             CompilationTest(input, kind);


### PR DESCRIPTION
Turns out passing function pointers as parameters to functions was not supported because the type of the parameter was not promoted to pointer type correctly.